### PR TITLE
Remove the use of a deprecated constructor

### DIFF
--- a/Dawnsbury.Mods.Weapons.StellarCannon/StarfinderWeapon.cs
+++ b/Dawnsbury.Mods.Weapons.StellarCannon/StarfinderWeapon.cs
@@ -1,6 +1,7 @@
 ﻿using Dawnsbury.Core.Mechanics.Enumerations;
 using Dawnsbury.Core.Mechanics.Treasure;
 using Dawnsbury.Core;
+using Dawnsbury.Display.Illustrations;
 
 namespace Dawnsbury.Mods.Weapons.StarfinderWeapons
 {
@@ -24,7 +25,7 @@ namespace Dawnsbury.Mods.Weapons.StarfinderWeapons
         {
 
         }
-        public GunItem(ItemName itemName, IllustrationName illustration, string name, int level, int price, params Trait[] traits) : base(itemName, illustration, name, level, price, traits)
+        public GunItem(ItemName itemName, IllustrationName illustration, string name, int level, int price, params Trait[] traits) : base(itemName, (Illustration)illustration, name, level, price, traits)
         {
         }
 


### PR DESCRIPTION
Your mod uses a constructor that I would like to remove from Dawnsbury Days. This PR makes the mod use the new replacement constructor. 

After the obsolete constructor is removed from Dawnsbury Days, that explicit cast to Illustration will no longer be necessary, but for now, it is.