### PR TITLE
Update the text of sci-fi mods to reflect the writing style of Dawnsbury Days

### DIFF
--- a/Dawnsbury.Mods.Ancestries.StarfinderAndroid/StarfinderAndroidAncestryFeats.cs
+++ b/Dawnsbury.Mods.Ancestries.StarfinderAndroid/StarfinderAndroidAncestryFeats.cs
@@ -10,7 +10,7 @@ namespace Dawnsbury.Mods.Ancestries.Starfinder
     {
         public static Feat CreateSkillProgramming()
         {
-            return new StarfinderAndroidFeat("Skill Programming", "You were programmed with extra skill training or found a way to download programming to improve your skills.", "You become trained in two additional skills")
+            return new StarfinderAndroidFeat("Skill Programming", "You were programmed with extra skill training or found a way to download programming to improve your skills.", "You become trained in two additional skills.")
             .WithOnSheet((sheet) =>
             {
                 sheet.AddSelectionOption(new SingleFeatSelectionOption("Skill Programming", "Skill Programming skill", 1, (Feat feat) => feat is SkillSelectionFeat));
@@ -20,11 +20,11 @@ namespace Dawnsbury.Mods.Ancestries.Starfinder
 
         public static Feat CreateCleansingSubroutine()
         {
-            return new StarfinderAndroidFeat("Cleansing Subroutine", "Your nanites help purge your body of harmful toxins"
-                , "Each time you attempt a saving throw against a poison effect, you improve your saving throw by one step").WithPermanentQEffect((qf) =>
+            return new StarfinderAndroidFeat("Cleansing Subroutine", "Your nanites help purge your body of harmful toxins."
+                , "Each time you attempt a saving throw against a poison effect, you improve your saving throw by one step.").WithPermanentQEffect((qf) =>
                 {
                     qf.Name = "Cleansing Subroutine";
-                    qf.Description = "Each time you attempt a saving throw against a poison effect, you improve your saving throw by one step";
+                    qf.Description = "Each time you attempt a saving throw against a poison effect, you improve your saving throw by one step.";
                     qf.AdjustSavingThrowResult = (qfself, action, result) =>
                     {
                         if (action.Traits.Contains(Trait.Poison))
@@ -97,7 +97,7 @@ namespace Dawnsbury.Mods.Ancestries.Starfinder
                         || action.Name == "Shove"
                         || action.Name.Contains("Escape"))
                         {
-                            bool useReaction = await target.Battle.AskToUseReaction(qf.Owner, "would you like to use Nanite Surge to give yourself a +2 status bonus to this check?");
+                            bool useReaction = await target.Battle.AskToUseReaction(qf.Owner, "Would you like to use Nanite Surge to give yourself a +2 status bonus to this check?");
                             if (useReaction)
                             {
                                 qfself.Owner.Actions.UseUpReaction();

--- a/Dawnsbury.Mods.Ancestries.StarfinderAndroid/StarfinderAndroidLoader.cs
+++ b/Dawnsbury.Mods.Ancestries.StarfinderAndroid/StarfinderAndroidLoader.cs
@@ -28,7 +28,7 @@ namespace Dawnsbury.Mods.Ancestries.Starfinder
         [DawnsburyDaysModMainMethod]
         public static void LoadMod()
         {
-            NanitesActive = new QEffect("Nanites Active", "The Androids Nanites are currently in use, and cannot be used for other nanite actions, activities, or reactions");
+            NanitesActive = new QEffect("Nanites Active", "The android's nanites are currently in use, and cannot be used for other nanite actions, activities, or reactions.");
             AndroidTrait = ModManager.RegisterTrait("Android", new TraitProperties("Android", true) { IsAncestryTrait = true});
             Tech = ModManager.RegisterTrait("Tech", new TraitProperties("Tech", true, "Incorporates electronics,computer systems, and power sources.", true));
             Radiation = ModManager.RegisterTrait("Radiation", new TraitProperties("Radiation", true, null, true));
@@ -45,7 +45,7 @@ namespace Dawnsbury.Mods.Ancestries.Starfinder
         {
             Feat ConstructedFeat = new Feat(FeatName.CustomFeat, "Your synthetic body resists ailments better than that of a purely biological organism."
                 , "You gain a +1 circumstance bonus to saving throws against diseases, poisons, and radiation.", new List<Trait> { }, null).WithCustomName("Constructed")
-                .WithPermanentQEffect("+1 circumstance bonus to saving throws against diseases, poisons, and radiation.",(qf)=>
+                .WithPermanentQEffect("You have a +1 bonus to saving throws against diseases, poisons, and radiation.",(qf)=>
                 {
                     qf.BonusToDefenses = (qfself, action, defense) =>
                     {
@@ -63,7 +63,7 @@ namespace Dawnsbury.Mods.Ancestries.Starfinder
 
             Feat EmotionallyUnawareFeat = new Feat(FeatName.CustomFeat, "You sometimes find it difficult to process and express complex emotions."
                 , "You take a –1 circumstance penalty to Diplomacy and Performance checks.", new List<Trait> { }, null).WithCustomName("Emotionally Unaware")
-                .WithPermanentQEffect("-1 circumstance penalty to emotion related checks", (qf) =>
+                .WithPermanentQEffect("You have a -1 penalty to emotion-related checks.", (qf) =>
                 {
                     qf.BonusToSkillChecks = (skill, action, creature) =>
                     {
@@ -76,7 +76,7 @@ namespace Dawnsbury.Mods.Ancestries.Starfinder
                     };
                 });
 
-            Feat starfinderAndroid = new AncestrySelectionFeat(FeatName.CustomFeat, "it's an android, but from starfinder", new List<Trait> { Trait.Humanoid, Tech, AndroidTrait }, 8, 5,
+            Feat starfinderAndroid = new AncestrySelectionFeat(FeatName.CustomFeat, "It's an android, but from Starfinder.", new List<Trait> { Trait.Humanoid, Tech, AndroidTrait }, 8, 5,
                 new List<AbilityBoost>()
                 {
                     new EnforcedAbilityBoost(Ability.Dexterity),
@@ -107,7 +107,7 @@ namespace Dawnsbury.Mods.Ancestries.Starfinder
                 .WithCustomName("Skill Specifications");
             yield return new HeritageSelectionFeat(FeatName.CustomFeat,
                 "Your body was originally forged for combat, likely created to function as a security officer or soldier.",
-                "you are trained in all simple and martial weapons")
+                "You are trained in all simple and martial weapons.")
                 .WithOnSheet(sheet =>
                 {
                     sheet.SetProficiency(Trait.Simple, Proficiency.Trained);

--- a/Dawnsbury.Mods.Classes.StarfinderSoldier/SoldierClassFeats.cs
+++ b/Dawnsbury.Mods.Classes.StarfinderSoldier/SoldierClassFeats.cs
@@ -32,7 +32,7 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
         public static Feat CreatePinDown()
         {
             return new SoldierFeat("Pin-Down", 1, "",
-            "Requirements Your last action was an attack with an area weapon. Select one creature that was in the area of effect of your prior attack. That creature must make a save against your attack again. This effect deals no damage but can inflict the suppressed condition on a target who previously saved against it."
+            "{b}Requirements{/b} Your last action was an attack with an area weapon.\n\nSelect one creature that was in the area of effect of your last attack. That creature must make a save against your attack again. This effect deals no damage but can inflict the Suppressed condition on a target who previously saved against it."
             , new[] { StarfinderSoldierLoader.SoldierTrait, Trait.ClassFeat }).WithActionCost(1).WithOnCreature((creature) =>
             {
                 CombatAction areaAction = null;
@@ -68,20 +68,20 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
                                 ProvideMainAction = (qfSelf) =>
                                 {
                                     CombatAction pinDownAction = new CombatAction(creature, IllustrationName.TakeCover, "Pin-Down", new[] { StarfinderSoldierLoader.SoldierTrait, }
-                                    , "Select one creature that was in the area of effect of your prior attack. That creature must make a save against your attack again. This effect deals no damage but can inflict the suppressed condition on a target who previously saved against it."
+                                    , "Select one creature that was in the area of effect of your last attack. That creature must make a save against your attack again. This effect deals no damage but can inflict the Suppressed condition on a target who previously saved against it."
                                     , CreatureTarget.Distance(100).WithAdditionalConditionOnTargetCreature((caster, defender) =>
                                     {
                                         if (defender == null)
                                         {
-                                            return Usability.NotUsable("no target chosen");
+                                            return Usability.NotUsable("No target chosen.");
                                         }
                                         if (!pastAction.ChosenTargets.ChosenCreatures.Contains(defender))
                                         {
-                                            return Usability.NotUsableOnThisCreature("Target not in area of last attack");
+                                            return Usability.NotUsableOnThisCreature("target not in area of last attack");
                                         }
                                         if (defender.DeathScheduledForNextStateCheck)
                                         {
-                                            return Usability.NotUsableOnThisCreature("Target about to die");
+                                            return Usability.NotUsableOnThisCreature("target about to die");
                                         }
                                         return Usability.Usable;
                                     })).WithActionCost(1).WithSavingThrow(new SavingThrow(Defense.Reflex, (creature) =>
@@ -92,9 +92,9 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
                                     {
                                         if (result == CheckResult.Failure || result == CheckResult.CriticalFailure)
                                         {
-                                            if (target.QEffects.Any(ef => ef.Name == "Supressed"))
+                                            if (target.QEffects.Any(ef => ef.Name == "Suppressed"))
                                             {
-                                                target.RemoveAllQEffects(ef => ef.Name == "Supressed");
+                                                target.RemoveAllQEffects(ef => ef.Name == "Suppressed");
                                             }
                                             target.AddQEffect(SoldierStatusEffects.GenerateSupressedEffect(caster).WithExpirationAtStartOfSourcesTurn(caster, 1));
                                         }
@@ -121,13 +121,13 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
         public static Feat QuickSwapFeat()
         {
             return new SoldierFeat("Quick-Swap", 1, "",
-            "Trigger You are wielding a two-handed weapon and a hostile creature moves adjacent to you. If you are wielding a two handed ranged weapon, you stow your current weapon and draw the first two-handed melee weapon in your inventory. If you are wielding a two handed melee weapon, you instead stow your current weapon and draw the first two handed range weapon in your inventory."
+            "{b}Trigger{/b} You are wielding a two-handed weapon and a hostile creature moves adjacent to you. If you are wielding a two-handed ranged weapon, you stow your current weapon and draw the first two-handed melee weapon in your inventory. If you are wielding a two-handed melee weapon, you instead stow your current weapon and draw the first two-handed ranged weapon in your inventory."
             , new[] { StarfinderSoldierLoader.SoldierTrait, Trait.ClassFeat }).WithOnCreature((creature) =>
             {
                 Creature lastCreatureToAct = null;
                 int lastActionsLeft= 4;
                 bool alreadyAsked = false;
-                creature.AddQEffect(new QEffect("Quick-Swap", "Trigger You are wielding a two-handed weapon and a hostile creature moves adjacent to you. If you are wielding a two handed ranged weapon, you stow your current weapon and draw the first two-handed melee weapon in your inventory. If you are wielding a two handed melee weapon, you instead stow your current weapon and draw the first two handed range weapon in your inventory.")
+                creature.AddQEffect(new QEffect("Quick-Swap", "When you are wielding a two-handed weapon and a hostile creature moves adjacent to you, you can swap a two-handed melee weapon in your hand for a two-handed ranged weapon in your inventory or vice versa.")
                 {
                     //when a creature first moves within 5 feet of this creature, find the first two-handed melee (if carrying ranged) or ranged (if carrying melee) weapon in inventory.
                     //ask player if they want to switch to that weapon, if yes, switch the held weapon.
@@ -198,7 +198,7 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
                                 return;
                             }
 
-                            ConfirmationRequest req = new ConfirmationRequest(creature, "Would you like to swap to " + swapToItem.Name + "?", IllustrationName.Reaction, "yes", "no");
+                            ConfirmationRequest req = new ConfirmationRequest(creature, "Would you like to swap to " + swapToItem.Name + "?", IllustrationName.Reaction, "Yes", "Pass");
 
                             //req.PassByButtonText = "passing";
                             alreadyAsked = true;
@@ -228,7 +228,9 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
         {
             return new SoldierFeat("Menacing Laughter", 2, "",
             "Attempt Intimidation checks to Demoralize each creature within 30 feet who you suppressed this turn."
-            , new[] { StarfinderSoldierLoader.SoldierTrait, Trait.ClassFeat }).WithOnCreature((creature) =>
+            , new[] { StarfinderSoldierLoader.SoldierTrait, Trait.ClassFeat })
+                .WithActionCost(1)
+                .WithOnCreature((creature) =>
             {
                 creature.AddQEffect(new QEffect()
                 {
@@ -247,7 +249,7 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
                             {
                                 return false;
                             }
-                            if (creature.QEffects.Any(q => q.Source == self && q.Name == "Supressed"))
+                            if (creature.QEffects.Any(q => q.Source == self && q.Name == "Suppressed"))
                             {
                                 return true;
                             }
@@ -277,7 +279,7 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
         public static Feat RelentlessEnduranceFeat()
         {
             return new SoldierFeat("Relentless Endurance", 2, "",
-            "Trigger You take damage.\r\nFrequency once per encounter\r\nYou come back stronger. You gain 1d8+4 temporary Hit Points that last for the encounter."
+            "{b}Trigger{/b} You take damage.\r\n{b}Frequency{/b} once per encounter\n\nYou come back stronger. You gain 1d8+4 temporary Hit Points that last for the rest of the encounter."
             , new[] { StarfinderSoldierLoader.SoldierTrait, Trait.ClassFeat }).WithOnCreature((creature) =>
             {
                 bool enduranceUsed = false;
@@ -287,7 +289,7 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
                 {
                     if (!enduranceUsed && creature.Actions.CanTakeReaction() && amount > 0)
                     {
-                        ConfirmationRequest req = new ConfirmationRequest(creature, "Would you like to use Relentless Endurance to gain 1d8+4 temporary HP?", IllustrationName.Reaction, "yes", "no");
+                        ConfirmationRequest req = new ConfirmationRequest(creature, "Would you like to use Relentless Endurance to gain 1d8+4 temporary HP?", IllustrationName.Reaction, "Yes", "Pass");
 
                         var enduranceResult = (await creature.Battle.SendRequest(req)).ChosenOption;
                         if (enduranceResult is ConfirmOption)
@@ -300,7 +302,7 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
                     }
                 }
 
-                creature.AddQEffect(new QEffect("Relentless Endurance", "Trigger You take damage.\r\nFrequency once per encounter\r\nYou come back stronger. You gain 1d8+4 temporary Hit Points that last for the encounter.")
+                creature.AddQEffect(new QEffect("Relentless Endurance", "When you take damage, once per encounter, you gain 1d8+4 temporary Hit Points.")
                 {
                     //makes sure the feat can be used only once per combat
                     StartOfCombat = async (qfself) =>
@@ -333,10 +335,10 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
                             {
                                 return null;
                             }
-                            if(target.QEffects.Any(fx=>fx.Name == "Supressed"))
+                            if(target.QEffects.Any(fx=>fx.Name == "Suppressed"))
                             {
                                 var num = Math.Min(creature.Actions.AttackedThisManyTimesThisTurn, 2);
-                                return new Bonus(num, BonusType.Untyped, "Overwhelming Assault Multiple Attack Penalty Reduction");
+                                return new Bonus(num, BonusType.Untyped, "Overwhelming Assault multiple attack penalty reduction");
                             }
                             return null;
                         }
@@ -351,12 +353,14 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
         public static Feat PunishingSalvoFeat()
         {
             return new SoldierFeat("Punishing Salvo", 4, "",
-                "Requirements Your last action this turn was a primary target Strike.\r\nYou can make a second Strike against your primary target, ignoring the effect of the unwieldy trait that prevents additional attacks. This doesn’t make a new area attack and is instead treated as just a single Strike against the target made using the primary target rules.",
-                new[] { StarfinderSoldierLoader.SoldierTrait, Trait.ClassFeat }).WithOnCreature((creature) => 
+                "{b}Requirements{/b} Your last action this turn was a primary target Strike.\r\nYou can make a second Strike against your primary target, ignoring the effect of the unwieldy trait that prevents additional attacks. This doesn't make a new area attack and is instead treated as just a single Strike against the target made using the primary target rules.",
+                new[] { StarfinderSoldierLoader.SoldierTrait, Trait.ClassFeat })
+                .WithActionCost(1)
+                .WithOnCreature((creature) => 
                 {
                     Item lastActionPrimStrikeWeapon = null;
                     Creature strikedCreature = null;
-                    creature.AddQEffect(new QEffect("Punishing Salvo", "Requirements Your last action this turn was a primary target Strike.\r\nYou can make a second Strike against your primary target, ignoring the effect of the unwieldy trait that prevents additional attacks. This doesn’t make a new area attack and is instead treated as just a single Strike against the target made using the primary target rules.")
+                    creature.AddQEffect(new QEffect("Punishing Salvo", "{b}Requirements{/b} Your last action this turn was a primary target Strike.\n\nYou can make a second Strike against your primary target, ignoring the effect of the unwieldy trait that prevents additional attacks. This doesn't make a new area attack and is instead treated as just a single Strike against the target made using the primary target rules.")
                     {
                         //if the last action you took was to attempt to strike a primary target, enable the punishing salvo action
                         AfterYouTakeHostileAction = (qfself,action) =>
@@ -397,7 +401,7 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
                                         var strikeTraits = areaItem.Traits;
                                         strikeTraits.Add(StarfinderSoldierLoader.SoldierTrait);
                                         var punishSalvo = new CombatAction(creature, IllustrationName.TrueStrike, "Punishing Salvo", strikeTraits.ToArray(),
-                                            "make a second Strike against the primary target of your last area attack, ignoring the effect of the unwieldy trait that prevents additional attacks.",
+                                            "Make a second Strike against the primary target of your last area attack, ignoring the effect of the unwieldy trait that prevents additional attacks.",
                                             Target.Ranged(areaItem.WeaponProperties.RangeIncrement * 5).WithAdditionalConditionOnTargetCreature((creature, target) =>
                                             {
                                                 return target == targetCreature ? Usability.Usable : Usability.NotUsableOnThisCreature("not the primary target of last area attack");

--- a/Dawnsbury.Mods.Classes.StarfinderSoldier/SoldierStatusEffects.cs
+++ b/Dawnsbury.Mods.Classes.StarfinderSoldier/SoldierStatusEffects.cs
@@ -13,22 +13,22 @@ namespace Dawnsbury.Mods.Classes.StarfinderSoldier
         /// generates the status effect "supressed".
         /// </summary>
         /// <param name="Supressor">the creature suppressing others</param>
-        /// <returns>the supressed effect</returns>
+        /// <returns>the suppressed effect</returns>
         public static QEffect GenerateSupressedEffect(Creature Supressor)
         {
-            QEffect effect = new QEffect("Supressed", "-1 circumstance penalty on attack rolls and a -10-foot status penalty to your speed", ExpirationCondition.CountsDownAtStartOfSourcesTurn, Supressor, IllustrationName.TakeCover)
+            QEffect effect = new QEffect("Suppressed", "You have a -1 circumstance penalty to attack rolls and a -10-foot status penalty to your Speed.", ExpirationCondition.CountsDownAtStartOfSourcesTurn, Supressor, IllustrationName.TakeCover)
             {
                 BonusToAttackRolls = (qfSelf, combatAction, target) =>
                 {
                     if (combatAction.Traits.Contains(Core.Mechanics.Enumerations.Trait.Strike))
                     {
-                        return new Core.Mechanics.Core.Bonus(-1, Core.Mechanics.Core.BonusType.Circumstance, "Supressed", false);
+                        return new Core.Mechanics.Core.Bonus(-1, Core.Mechanics.Core.BonusType.Circumstance, "Suppressed", false);
                     }
                     return null;
                 },
                 BonusToAllSpeeds = (qfSelf) =>
                 {
-                    return new Core.Mechanics.Core.Bonus(-2, Core.Mechanics.Core.BonusType.Status, "Supressed", false);
+                    return new Core.Mechanics.Core.Bonus(-2, Core.Mechanics.Core.BonusType.Status, "Suppressed", false);
                 }
             };
 

--- a/Dawnsbury.Mods.Classes.StarfinderSoldier/StarfinderSoldierLoader.cs
+++ b/Dawnsbury.Mods.Classes.StarfinderSoldier/StarfinderSoldierLoader.cs
@@ -46,9 +46,9 @@ public class StarfinderSoldierLoader
 
         SuppressedIllustration = new ModdedIllustration(@"StarfinderSoldierResources\Suppressed.png");
 
-        FearsomeBulwarkFeat = new Feat(FeatName.CustomFeat, "Fearsome Bulwark", "You can use your Constitution modifier instead of your Charisma modifier on Intimidation checks, this does not show up on your character sheet", new List<Trait>(), new List<Feat>()).WithOnCreature((creature) =>
+        FearsomeBulwarkFeat = new Feat(FeatName.CustomFeat, "Fearsome Bulwark", "You can use your Constitution modifier instead of your Charisma modifier on Intimidation checks (this does not show up on your character sheet).", new List<Trait>(), new List<Feat>()).WithOnCreature((creature) =>
         {
-            creature.AddQEffect(new QEffect("Fearsome Bulwark", "You can use your Constitution modifier instead of your Charisma modifier on Intimidation checks, this does not show up on your character sheet.")
+            creature.AddQEffect(new QEffect("Fearsome Bulwark", "You can use your Constitution modifier instead of your Charisma modifier on Intimidation checks (this does not show up on your character sheet).")
             {
                 BonusToSkillChecks = (skill, combatAction, creature) =>
                 {
@@ -83,13 +83,13 @@ public class StarfinderSoldierLoader
     /// <returns>the Soldier class selection feat</returns>
     private static Feat GenerateClassSelectionFeat()
     {
-        var soldierSelection = new ClassSelectionFeat(FeatName.CustomFeat, "master of area weapons, heavy armor, and taking punishment.", SoldierTrait,
+        var soldierSelection = new ClassSelectionFeat(FeatName.CustomFeat, "Master of area weapons, heavy armor, and taking punishment.", SoldierTrait,
             new EnforcedAbilityBoost(Ability.Constitution), 10, new[] { Trait.Perception, Trait.Reflex, Trait.Simple, Trait.Martial, Trait.Unarmed, Trait.UnarmoredDefense, Trait.LightArmor, Trait.MediumArmor, Trait.HeavyArmor },
-            new[] { Trait.Fortitude, Trait.Will }, 4, "1. Suppressing Fire:  Creatures in the affected area who fail their save against your attack become suppressed until the start of your next turn." +
-            "\r\n2. Primary Target: You may choose a primary target, if they are the closest creature to the area origin point of an area attack, you may also make a strike against that creature as part of that attack." +
-            "\r\n3. Fighting Style: As a soldier, you applied yourself to a specific style of combat. Your style determines how you tend to approach combat and how you take advantage of your ability to suppress targets." +
-            "\r\n4. WalkingArmory: When determining your Strength threshold for using medium or heavy armor, you can instead choose to use your Constitution modifier." +
-            "\r\nAt Later Levels:\r\n\r\n Level 3:\r\n1. Fearsome Bulwark: You can use your Constitution modifier instead of your Charisma modifier on Intimidation checks.", GenerateSoldierSubclasses()).WithCustomName("Soldier").WithOnCreature((creature)=>
+            new[] { Trait.Fortitude, Trait.Will }, 4, "{b}1. Suppressing Fire.{/b} Creatures who fail their save against your area attack from an area weapon become Suppressed until the start of your next turn." +
+            "\n\n{b}2. Primary Target.{/b} You may choose a primary target. If they are the closest creature to the area origin point of an area attack, you may also make a Strike against that creature as part of that attack." +
+            "\n\n{b}3. Fighting Style.{/b} As a Soldier, you applied yourself to a specific style of combat. Your style determines how you tend to approach combat and how you take advantage of your ability to suppress targets." +
+            "\n\n{b}4. Walking Armory.{/b} When determining your Strength threshold for using medium or heavy armor, you can instead choose to use your Constitution modifier." +
+            "\n\n{b}At higher levels:{/b}\n{b}Level 3:{/b} Fearsome Bulwark (you can use your Constitution modifier instead of your Charisma modifier on Intimidation checks)", GenerateSoldierSubclasses()).WithCustomName("Soldier").WithOnCreature((creature)=>
             {
                 SetupPrimaryTarget(creature);
                 SetupSoldierSuppression(creature);
@@ -97,7 +97,7 @@ public class StarfinderSoldierLoader
             }).WithOnSheet(sheet =>
             {
                 sheet.AddAtLevel(3, (values) => { values.AddFeat(FearsomeBulwarkFeat, null); });
-                sheet.AddSelectionOption(new SingleFeatSelectionOption("level1SoldierFeat", "Soldier Feat", 1, (feat) => feat.HasTrait(SoldierTrait) && feat is TrueFeat && ((TrueFeat)feat).Level == 1));
+                sheet.AddSelectionOption(new SingleFeatSelectionOption("level1SoldierFeat", "Soldier feat", 1, (feat) => feat.HasTrait(SoldierTrait) && feat is TrueFeat && ((TrueFeat)feat).Level == 1));
             });
         return soldierSelection;
     }
@@ -108,7 +108,7 @@ public class StarfinderSoldierLoader
     /// <param name="creature">the creature to add walking armory to</param>
     private static void SetupWalkingArmory(Creature creature)
     {
-        creature.AddQEffect(new QEffect("WalkingArmory","When determining your Strength threshold for using medium or heavy armor, you can instead choose to use your Constitution modifier.")
+        creature.AddQEffect(new QEffect("Walking Armory","When determining your Strength threshold for using medium or heavy armor, you can instead choose to use your Constitution modifier.")
         {
             StateCheck = (qfSelf)=>
             {
@@ -129,7 +129,7 @@ public class StarfinderSoldierLoader
         Creature actionOwner = creature;
         Creature mainTarget = null;
         creature.AddQEffect(
-        new QEffect("Primary Target", "You may choose a primary target, if they are the closest creature to the area origin point of an area attack, you may also make a strike against that creature as part of that attack.")
+        new QEffect("Primary Target", "You may choose a primary target. If they are the closest creature to the area origin point of an area attack, you may also make a Strike against that creature as part of that attack.")
         {
             //provides the free action to seelct a primary target
             StateCheck = (qfSelf) =>
@@ -144,8 +144,8 @@ public class StarfinderSoldierLoader
                             Creature thisCreature = actionOwner;
                             var addedText = (mainTarget != null ? "\n[currently: " + mainTarget.Name + "]" : string.Empty);
                             CombatAction SetPrimaryTarget = new CombatAction(actionOwner, IllustrationName.TrueStrike, "Select Primary Target" + addedText, new Trait[] { Trait.AlwaysHits, Trait.IsNotHostile, Trait.DoesNotBreakStealth },
-                                 "Select a foe, as long as they are the closest creature to the center of a Burst area fire or the closest creature to you when using a a cone or line area fire, you will also attempt to strike that creature.",
-                                 Target.RangedCreature(100).WithAdditionalConditionOnTargetCreature((caster, target) => target.FriendOf(caster) ? Usability.NotUsableOnThisCreature("cannot choose ally as primary target.") : Usability.Usable))
+                                 "Select a foe. As long as they are the closest creature to the center of a burst area fire or the closest creature to you when using a a cone or line area fire, you will also attempt to Strike that creature.",
+                                 Target.RangedCreature(100).WithAdditionalConditionOnTargetCreature((caster, target) => target.FriendOf(caster) ? Usability.NotUsableOnThisCreature("ally") : Usability.Usable))
                                  .WithActionCost(0)
                                 .WithEffectOnEachTarget(async (spell, caster, target, result) =>
                                 {
@@ -286,7 +286,7 @@ public class StarfinderSoldierLoader
     /// <param name="creature">the creature to add the ability to supress to.</param>
     private static void SetupSoldierSuppression(Creature creature)
     {
-        creature.AddQEffect(new QEffect("Suppressing Fire", "Creatures in the affected area who fail their save against your attack become suppressed until the start of your next turn.")
+        creature.AddQEffect(new QEffect("Suppressing Fire", "Creatures in the affected area who fail their save against your area attack become Suppressed until the start of your next turn.")
         {
             AfterYouTakeHostileAction = (qfSelf, action) =>
             {
@@ -309,9 +309,9 @@ public class StarfinderSoldierLoader
                     var result = chosen.CheckResults[chosenTarget];
                     if (result == CheckResult.Failure || result == CheckResult.CriticalFailure || (result == CheckResult.Success && action.Owner.Traits.Contains(BombardTechnical)))
                     {
-                        if (chosenTarget.QEffects.Any(ef => ef.Name == "Supressed"))
+                        if (chosenTarget.QEffects.Any(ef => ef.Name == "Suppressed"))
                         {
-                            chosenTarget.RemoveAllQEffects(ef => ef.Name == "Supressed");
+                            chosenTarget.RemoveAllQEffects(ef => ef.Name == "Suppressed");
                         }
                         chosenTarget.AddQEffect(SoldierStatusEffects.GenerateSupressedEffect(action.Owner).WithExpirationAtStartOfSourcesTurn(action.Owner, 1));
                     }
@@ -330,12 +330,12 @@ public class StarfinderSoldierLoader
         {
             new SoldierFightingStyleFeat(
             "Armor Storm",
-            "Your armor is like an extension of your skin (or other appropriate surface layer), and you’re able to leverage it alongside the heavy weapons you employ. Foes you suppress quickly stumble while attempting to overcome your durability, granting you an edge in\r\nabsorbing their incoming firepower. You likely move to the forefront and try to focus your enemy’s attention on yourself.",
-            "You never count as being in the area of a ranged weapon you’ve made an attack with. In addition, you gain resistance equal to half your level (minimum 1) against attacks made from suppressed targets.",
+            "Your armor is like an extension of your skin (or other appropriate surface layer), and you're able to leverage it alongside the heavy weapons you employ. Foes you suppress quickly stumble while attempting to overcome your durability, granting you an edge in absorbing their incoming firepower. You likely move to the forefront and try to focus your enemy's attention on yourself.",
+            "You never count as being in the area of a ranged weapon you've made an attack with. In addition, you gain resistance equal to half your level (minimum 1) against attacks made from suppressed targets.",
             new List<Trait>(),null).WithOnCreature((sheet, creature) =>
             {
                 creature.Traits.Add(ArmorStormTechnical);
-                creature.AddQEffect(new QEffect("Armor Storm","You never count as being in the area of a ranged weapon you’ve made an attack with. In addition, you gain resistance equal to half your level (minimum 1) against attacks made from suppressed targets.")
+                creature.AddQEffect(new QEffect("Armor Storm","You never count as being in the area of a ranged weapon you've made an attack with. In addition, you gain resistance equal to half your level (minimum 1) against attacks made from suppressed targets.")
                 {
                     AdjustSavingThrowResult = (qfSelf, action, result) =>
                     {
@@ -349,9 +349,9 @@ public class StarfinderSoldierLoader
                     {
                         Task<DamageModification> damageModTask = new Task<DamageModification>(() =>
                         {
-                            if (attacker.QEffects.Any((qft)=>qft.Name == "Supressed"))
+                            if (attacker.QEffects.Any((qft)=>qft.Name == "Suppressed"))
                             {
-                                return new ReduceDamageModification(Math.Max(Math.Max(self.Level / 2, 1) - self.WeaknessAndResistance.Resistances.FirstOrDefault(r => r.DamageKind == dStuff.Kind, new Resistance(DamageKind.Chaotic, 0)).Value, 0), "Resistance equal to 1/2 level (minimum 1) against supressed targets");
+                                return new ReduceDamageModification(Math.Max(Math.Max(self.Level / 2, 1) - self.WeaknessAndResistance.Resistances.FirstOrDefault(r => r.DamageKind == dStuff.Kind, new Resistance(DamageKind.Chaotic, 0)).Value, 0), "Resistance equal to 1/2 level (minimum 1) against suppressed targets");
                             }
                             else
                             {
@@ -365,12 +365,12 @@ public class StarfinderSoldierLoader
             }),
              new SoldierFightingStyleFeat(
             "Bombard",
-            "There’s nothing like a reliable heavy gun (or maybe several different types of heavy guns) to get you through the tough times of adventuring in space. You’ve come to terms with the fact that your weapons might sometimes hit your allies but work to minimize such instances of unintentional “friendly fire.” In fact, you’ve honed your skill with heavy weapons so much that all but the most indirect of strikes causes your opponents to duck down or force them to adapt to the havoc you unleash.",
-            "When you attack with an area weapon, you adjust the shot to allow allies to better avoid it. Your allies are not affected by your area attacks. In addition, enemies who succeed (but not critically succeed) their save against an area attack you make are still suppressed until the start of your next turn.",
+            "There's nothing like a reliable heavy gun (or maybe several different types of heavy guns) to get you through the tough times of adventuring in space. You've come to terms with the fact that your weapons might sometimes hit your allies but work to minimize such instances of unintentional \"friendly fire.\" In fact, you've honed your skill with heavy weapons so much that all but the most indirect of strikes causes your opponents to duck down or force them to adapt to the havoc you unleash.",
+            "When you attack with an area weapon, you adjust the shot to allow allies to better avoid it. Your allies are not affected by your area attacks. In addition, enemies who succeed (but not critically succeed) their save against an area attack you make are still Suppressed until the start of your next turn.",
             new List<Trait>(),null).WithOnCreature((sheet, creature) =>
             {
                 creature.Traits.Add(BombardTechnical);
-                creature.AddQEffect(new QEffect("Bombard","When you attack with an area weapon, you adjust the shot to allow allies to better avoid it. Your allies are not affected by your area attacks. In addition, enemies who succeed (but not critically succeed) their save against an area attack you make are still suppressed until the start of your next turn.")
+                creature.AddQEffect(new QEffect("Bombard","When you attack with an area weapon, you adjust the shot to allow allies to better avoid it. Your allies are not affected by your area attacks. In addition, enemies who succeed (but not critically succeed) their save against an area attack you make are still Suppressed until the start of your next turn.")
                 {
                     StartOfCombat = (qfSelf) =>
                     {

--- a/Dawnsbury.Mods.Weapons.StellarCannon/StarfinderWeaponsLoader.cs
+++ b/Dawnsbury.Mods.Weapons.StellarCannon/StarfinderWeaponsLoader.cs
@@ -50,14 +50,14 @@ public partial class StarfinderWeaponsLoader
     [DawnsburyDaysModMainMethod]
     public static void LoadMod()
     {
-        Analogue = ModManager.RegisterTrait("Analogue", new TraitProperties("Analogue", true, "Does not rely on digital technology.")); Tech = ModManager.RegisterTrait("Tech", new TraitProperties("Tech", true, "Incorporates electronics,computer systems, and power sources.", true));
-        Unwieldy = ModManager.RegisterTrait("Unwieldy", new TraitProperties("Unwieldy", true, "You can’t use an unwieldy weapon more than once per round and can’t use it to Strike as part of a reaction",true));
-        AreaBurst10ft = ModManager.RegisterTrait("AreaBurst10ft", new TraitProperties("Area (Burst 10 ft.)", true, "Weapons with this trait can only fire using the Area Fire action. The DC is equal to 10 + your attack bonus with this weapon using strength or constitution (except expert proficiency is treated as trained).", true));
-        AreaCone = ModManager.RegisterTrait("AreaCone", new TraitProperties("Area (Cone)", true, "Weapons with this trait can only fire using the Area Fire action. The DC is equal to 10 + your attack bonus with this weapon using strength or constitution (except expert proficiency is treated as trained).", true));
-        AreaLine = ModManager.RegisterTrait("AreaLine", new TraitProperties("Area (Line)", true, "Weapons with this trait can only fire using the Area Fire action. The DC is equal to 10 + your attack bonus with this weapon using strength or constitution (except expert proficiency is treated as trained).", true));
-        Concussive = ModManager.RegisterTrait("Concussive", new TraitProperties("Concussive", true, "Use the weaker of the target’s resistance or immunity\r\nto piercing or to bludgeoning."));
+        Analogue = ModManager.RegisterTrait("Analogue", new TraitProperties("Analogue", true, "Does not rely on digital technology.")); Tech = ModManager.RegisterTrait("Tech", new TraitProperties("Tech", true, "Incorporates electronics, computer systems, and power sources.", true));
+        Unwieldy = ModManager.RegisterTrait("Unwieldy", new TraitProperties("Unwieldy", true, "You can't use an unwieldy weapon more than once per round and can't use it to Strike as part of a reaction.",true));
+        AreaBurst10ft = ModManager.RegisterTrait("AreaBurst10ft", new TraitProperties("Area (Burst 10 ft.)", true, "Weapons with this trait can only fire using the Area Fire action. The DC is equal to 10 + your attack bonus with this weapon using Strength or Constitution (except that expert proficiency is treated as trained).", true));
+        AreaCone = ModManager.RegisterTrait("AreaCone", new TraitProperties("Area (Cone)", true, "Weapons with this trait can only fire using the Area Fire action. The DC is equal to 10 + your attack bonus with this weapon using Strength or Constitution (except that expert proficiency is treated as trained).", true));
+        AreaLine = ModManager.RegisterTrait("AreaLine", new TraitProperties("Area (Line)", true, "Weapons with this trait can only fire using the Area Fire action. The DC is equal to 10 + your attack bonus with this weapon using Strength or Constitution (except that expert proficiency is treated as trained).", true));
+        Concussive = ModManager.RegisterTrait("Concussive", new TraitProperties("Concussive", true, "Use the weaker of the target's resistance or immunity to piercing or to bludgeoning."));
         Area = ModManager.RegisterTrait("Area", new TraitProperties("Area", true, "The effect happens in a targeted area.", true));
-        Automatic = ModManager.RegisterTrait("Automatic", new TraitProperties("Automatic", true, "Can use the 'Automatic Fire' action.The DC is equal to 10 + your attack bonus with this weapon using strength, constitution, or dexterity (except expert proficiency is treated as trained).", true));
+        Automatic = ModManager.RegisterTrait("Automatic", new TraitProperties("Automatic", true, "Can use the 'Automatic Fire' action. The DC is equal to 10 + your attack bonus with this weapon using Strength, Constitution, or Dexterity (except that expert proficiency is treated as trained).", true));
         AutomaticTechnical = ModManager.RegisterTrait("AutomaticTechnical", new TraitProperties("AutomaticTechnical", false));
         AreaTechnical = ModManager.RegisterTrait("AreaTech", new TraitProperties("AreaTechnical", false));
         Gun = ModManager.RegisterTrait("Gun", new TraitProperties("Gun", true, "Fires projectiles and has a magazine.", false));
@@ -292,7 +292,7 @@ public partial class StarfinderWeaponsLoader
                 {
                     if (((EphemeralAreaProperties)gunItem.EphemeralItemProperties).CurrentMagazine < gunItem.Usage)
                     {
-                        return "Not Enough Ammo Loaded.";
+                        return "Not enough ammo loaded.";
                     }
                 }
                 return null;
@@ -306,7 +306,7 @@ public partial class StarfinderWeaponsLoader
             {
                 ProvideMainAction = (qfSelf) =>
                 {
-                    CombatAction reloadAction = new CombatAction(itemOwner, gunItem.Illustration, "Reload " + gunItem.Name, new[] { Trait.Interact }, "interact to reload", Target.Self()).WithActionCost(gunItem.Reload)
+                    CombatAction reloadAction = new CombatAction(itemOwner, gunItem.Illustration, "Reload " + gunItem.Name, new[] { Trait.Interact }, "Interact to reload.", Target.Self()).WithActionCost(gunItem.Reload)
                     .WithEffectOnSelf((self) => ((EphemeralAreaProperties)gunItem.EphemeralItemProperties).CurrentMagazine = gunItem.Capacity);
 
                     return new ActionPossibility(reloadAction);
@@ -357,7 +357,7 @@ public partial class StarfinderWeaponsLoader
                 {
                     if (((EphemeralAreaProperties)areaItem.EphemeralItemProperties).CurrentMagazine < areaItem.Usage)
                     {
-                        return "Not Enough Ammo Loaded.";
+                        return "Not enough ammo loaded.";
                     }
                 }
                 return null;
@@ -369,8 +369,7 @@ public partial class StarfinderWeaponsLoader
                 areaFireAction = new CombatAction(weaponOwner, IllustrationName.BurningJet,
                     areaItem.Name + " Area Fire",
                     new[] { Area, Trait.Attack, Trait.Manipulate },
-                    "DC " + GetBestAreaDC(weaponOwner, areaItem) + " Basic Reflex. " +
-                     "use an area fire weapon to attack in a " + effectRange * 5 + " ft. " + areaType + " for " + areaItem.WeaponProperties.Damage + " " + areaItem.WeaponProperties.DamageKind.ToString() + " damage.", target)
+                    "Use an area fire weapon to attack in a " + effectRange * 5 + "-foot " + areaType + " for " + areaItem.WeaponProperties.Damage + " " + areaItem.WeaponProperties.DamageKind.ToString() + " damage (basic DC " + GetBestAreaDC(weaponOwner, areaItem) + " Reflex save mitigates).", target)
                     { Item = areaItem }
                     .WithActionCost(2)
                     .WithSavingThrow(new SavingThrow(Defense.Reflex, (creature) =>
@@ -426,7 +425,7 @@ public partial class StarfinderWeaponsLoader
             {
                 if (action.Item == areaItem && ((EphemeralAreaProperties)areaItem.EphemeralItemProperties).CurrentMagazine < areaItem.Capacity / 2 && action.Traits.Contains(AutomaticTechnical))
                 {
-                    return "You need half your magazine loaded to autofire";
+                    return "You need half your magazine loaded to autofire.";
                 }
                 return null;
             },
@@ -440,8 +439,7 @@ public partial class StarfinderWeaponsLoader
                     autoFireAction = new CombatAction(weaponOwner, IllustrationName.HailOfSplinters,
                         areaItem.Name + " Automatic Fire",
                         new[] { Area, Trait.Attack, AutomaticTechnical, Trait.Manipulate},
-                        "DC " + GetBestAreaDC(weaponOwner, areaItem, true) + " Basic Reflex. " +
-                         "use an automatic fire weapon to attack in a " + effectRange * 5 + " ft. cone for " + areaItem.WeaponProperties.Damage + " " + areaItem.WeaponProperties.DamageKind.ToString() + " damage.", Target.Cone(effectRange))
+                         "Use an automatic fire weapon to attack in a " + effectRange * 5 + "-foot cone for " + areaItem.WeaponProperties.Damage + " " + areaItem.WeaponProperties.DamageKind.ToString() + " damage (basic DC " + GetBestAreaDC(weaponOwner, areaItem, true) + " Reflex save mitigates).", Target.Cone(effectRange))
                     { Item = areaItem }
                         .WithActionCost(2)
                         .WithSavingThrow(new SavingThrow(Defense.Reflex, (creature) =>


### PR DESCRIPTION
This PR makes changes to the texts inside your mods:

- It fixes grammar, punctuation and capitalization.
- It fixes the "Supressed" typo.
- It adds action cost to feats that require actions.
- It adjust some QEffect and CombatAction descriptions to be as though they were in Dawnsbury Days core.

Feel free to accept only some of these changes if you like something in your original style more. For example, to save space, I avoid writing bonus types in the stat block, but you may think it's important to show them there.